### PR TITLE
Update MapBuilder

### DIFF
--- a/Assets/Scripts/Tiled/MapBuilder.cs
+++ b/Assets/Scripts/Tiled/MapBuilder.cs
@@ -99,7 +99,7 @@ namespace Tiled.Builder {
                             }
                         }
 
-                        t.transform.parent = holder.transform;
+                        t.transform.SetParent(holder.transform);
                     }
 
                     x++;


### PR DESCRIPTION
tile were all at the same place due to change in parenting in more recent version of unity. We have to use SetParent instead of directly assign the new parent.